### PR TITLE
Remove escape

### DIFF
--- a/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
+++ b/lib/acts_as_taggable_on/taggable/tagged_with_query/query_base.rb
@@ -48,7 +48,8 @@ module ActsAsTaggableOn::Taggable::TaggedWithQuery
 
     def escaped_tag(tag)
       tag = tag.downcase unless ActsAsTaggableOn.strict_case_match
-      tag.gsub(/[!%_]/) { |x| '!' + x }
+      # tag.gsub(/[!%_]/) { |x| '!' + x }
+      tag
     end
 
     def adjust_taggings_alias(taggings_alias)


### PR DESCRIPTION
Comment out statements to add tags escape string("!").
After this change merged, the strings escaped in previous versoin such as "%" cannot be escaped automatically.